### PR TITLE
Auto Capture

### DIFF
--- a/content/artifacts/artifactory/README.md
+++ b/content/artifacts/artifactory/README.md
@@ -7,4 +7,4 @@ The artifactory plugin is your one-stop-shop for things related to artifacts.
 * Withdraw artifacts once they are unlocked
 * See bonuses of your artifacts
 * Deposit artifacts on your planets
-* Find untaken planets with artifacts and jump to them
+* Find untaken planets with artifacts, jump to them, and capture them with a click

--- a/javascript/utils/utils.js
+++ b/javascript/utils/utils.js
@@ -55,6 +55,14 @@ export let canStatUpgrade = (planet, stat) => {
   return canUpgrade[stat];
 }
 
+const canCapture = (fromPlanet, toPlanet, maxEnergyPercent) => {
+  const energyNeededUponArrivalDoubled = planetToTake.energy * 2;
+  const energyNeededToSend = df.getEnergyNeededForMove(fromPlanet.locationId, toPlanet.locationId, energyNeededUponArrivalDoubled);
+  const fromPlanetEnergy = sendingPlanet.energy * (maxEnergyPercent/100);
+
+  return fromPlanetEnergy >= energyNeededToSend;
+}
+
 export let isAsteroid = (planet) => planet.planetResource === 1
 
 export let getPlanetRank = (planet) => {


### PR DESCRIPTION
adds a Capture button

<img width="492" alt="Screen Shot 2020-12-30 at 5 23 33 PM" src="https://user-images.githubusercontent.com/12127609/103386307-246f7480-4acc-11eb-8a81-271bf45885b6.png">

Each untaken artifact planet cycles through your planets until it can find a planet that can capture the artifact planet with 2x energy. i.e. if the planet needs 8 energy to be captured, your planet will send 16 energy. It will only use up to 85% of your planets energy to do it.