### PR TITLE
harmonize getArrivalsForPlanet to filter for pending arrivals only

### DIFF
--- a/content/artifacts/hunt-artifacts/plugin.js
+++ b/content/artifacts/hunt-artifacts/plugin.js
@@ -147,7 +147,7 @@ function captureArtifacts(fromId, maxDistributeEnergyPercent) {
 }
 
 function getArrivalsForPlanet(planetId) {
-  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId);
+  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId).filter(p => p.arrivalTime > Date.now() / 1000);
 }
 
 //returns tuples of [planet,distance]

--- a/content/productivity/crawl-planets/plugin.js
+++ b/content/productivity/crawl-planets/plugin.js
@@ -177,7 +177,7 @@ function capturePlanets(fromId, minCaptureLevel, maxDistributeEnergyPercent) {
 }
 
 function getArrivalsForPlanet(planetId) {
-  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId);
+  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId).filter(p => p.arrivalTime > Date.now() / 1000);
 }
 
 //returns tuples of [planet,distance]

--- a/content/productivity/distribute-silver/plugin.js
+++ b/content/productivity/distribute-silver/plugin.js
@@ -186,7 +186,7 @@ function distance(from, to) {
 }
 
 function getArrivalsForPlanet(planetId) {
-  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId);
+  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId).filter(p => p.arrivalTime > Date.now() / 1000);
 }
 
 plugin.register(new Plugin());

--- a/javascript/utils/RepeatAttackCore.js
+++ b/javascript/utils/RepeatAttackCore.js
@@ -112,7 +112,7 @@ function findWeapons(
   return mapped.map((p) => p.planet).slice(0, numOfPlanets);
 }
 function planetIsRevealed(planetId) {
-  return !!contractsAPI.getLocationOfPlanet(planetId);
+  return !!df.getLocationOfPlanet(planetId);
 }
 async function waitingForPassengers(locationId, passengersArray) {
   const arrivals = getArrivalsForPlanet(locationId);

--- a/javascript/utils/RepeatAttackCore.js
+++ b/javascript/utils/RepeatAttackCore.js
@@ -1,13 +1,7 @@
 function checkNumInboundVoyages(planetId, from = "") {
   if (from == "") {
     return (
-      df
-        .getAllVoyages()
-        .filter(
-          (v) =>
-            v.toPlanet == planetId &&
-            v.arrivalTime > new Date().getTime() / 1000
-        ).length +
+      getArrivalsForPlanet(planetId).length +
       df.getUnconfirmedMoves().filter((m) => m.to == planetId).length
     );
   } else {
@@ -121,7 +115,8 @@ function planetIsRevealed(planetId) {
   return !!contractsAPI.getLocationOfPlanet(planetId);
 }
 async function waitingForPassengers(locationId, passengersArray) {
-  const arrivals = await df.contractsAPI.getArrivalsForPlanet(locationId);
+  const arrivals = getArrivalsForPlanet(locationId);
+
   return (
     arrivals
       .filter((a) => a.player == df.account)
@@ -639,9 +634,7 @@ async function capturePlanets(
       const candidate = candidates_[i++][0];
 
       // Check if has incoming moves from another planet to safe
-      const arrivals = await df.contractsAPI.getArrivalsForPlanet(
-        candidate.locationId
-      );
+      const arrivals = getArrivalsForPlanet(candidate.locationId);
       if (arrivals.length !== 0) {
         continue;
       }
@@ -715,9 +708,7 @@ async function distributeSilver(fromId, maxDistributeEnergyPercent) {
     const candidate = candidates_[i++][0];
 
     // Check if has incoming moves from a previous asteroid to be safe
-    const arrivals = await df.contractsAPI.getArrivalsForPlanet(
-      candidate.locationId
-    );
+    const arrivals = getArrivalsForPlanet(candidate.locationId);
     if (arrivals.length !== 0) {
       continue;
     }
@@ -753,6 +744,10 @@ async function distributeSilver(fromId, maxDistributeEnergyPercent) {
     energySpent += energyNeeded;
     silverSpent += silverNeeded;
   }
+}
+
+function getArrivalsForPlanet(planetId) {
+  return df.getAllVoyages().filter(arrival => arrival.toPlanet === planetId).filter(p => p.arrivalTime > Date.now() / 1000);
 }
 
 function checkPlanetUpgradeLevel(planet) {


### PR DESCRIPTION
Get all voyages is all voyages since youve started the game, so it has 'expired' voyages in it. 
Ultimately should pull this into a util function, but for now a quick fix

Ping @Bind to make sure I didnt break repeatattack