### PR TITLE
define isActivated(artifact)

### DIFF
--- a/javascript/utils/queued-move.js
+++ b/javascript/utils/queued-move.js
@@ -169,6 +169,12 @@ async function snark(actionId, oldX, oldY, newX, newY) {
   }
 }
 
+function isActivated(artifact) {
+  if (artifact === undefined) {
+    return false;
+  }
+}
+
 // Kinda like GameManager.move() but without localstorage and using our queue
 export function move(from, to, forces, silver, artifactMoved) {
   const oldLocation = df.entityStore.getLocationOfPlanet(from);


### PR DESCRIPTION
Appears like the move function has been copied from https://github.com/darkforest-eth/plugins/blob/ca77c3b008c35f2eef57eb22a5d585fb23093f01/content/productivity/remote-snarker/plugin.js#L191

That relies on a function `isActivated` that is not defined in queued-move and causes the following error message when move with artifact is called from a plugin
```
Uncaught ReferenceError: isActivated is not defined
```