### PR TITLE
DEPRECATE: hide-small-planets plugin

### DIFF
--- a/content/casual/hide-small-planets/index.md
+++ b/content/casual/hide-small-planets/index.md
@@ -2,5 +2,5 @@
 title: Hide Small Planets
 date: 2021-01-16
 subtitle: Keep your focus on the big ones!
-version: 0.5.0
+version: 0.6.0
 ---

--- a/content/casual/hide-small-planets/index.md
+++ b/content/casual/hide-small-planets/index.md
@@ -2,5 +2,6 @@
 title: Hide Small Planets
 date: 2021-06-13
 subtitle: Keep your focus on the big ones!
-version: [DEPRECATED]
+version: 0.6.0
+deprecated: true
 ---

--- a/content/casual/hide-small-planets/index.md
+++ b/content/casual/hide-small-planets/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hide Small Planets
-date: 2021-06-13
+date: 2021-01-16
 subtitle: Keep your focus on the big ones!
 version: 0.6.0
 deprecated: true

--- a/content/casual/hide-small-planets/index.md
+++ b/content/casual/hide-small-planets/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hide Small Planets
-date: 2021-01-16
+date: 2021-06-13
 subtitle: Keep your focus on the big ones!
 version: [DEPRECATED]
 ---

--- a/content/casual/hide-small-planets/index.md
+++ b/content/casual/hide-small-planets/index.md
@@ -2,5 +2,5 @@
 title: Hide Small Planets
 date: 2021-01-16
 subtitle: Keep your focus on the big ones!
-version: 0.6.0
+version: [DEPRECATED]
 ---

--- a/content/casual/hide-small-planets/plugin.js
+++ b/content/casual/hide-small-planets/plugin.js
@@ -60,4 +60,4 @@ class Plugin {
   }
 }
 
-plugin.register(new Plugin());
+export default Plugin;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
 
       {{ range ((((where .Site.Pages "Kind" "page").ByParam "date")).ByParam "version").Reverse   }}
       {{ if ne .Params.Exclude true }}
+      {{ if ne .Params.deprecated true }}
       <a target="_blank" rel="noopener"
         href="https://github.com/{{ .Site.Params.Repo }}/blob/{{ .Site.Params.Branch }}/content/{{ .File.Dir }}plugin.js"
         class="card border-2 border-green-400 sm:mb-4 mb-6 hover:shadow-xl hover:bg-green-400 text-gray-400 hover:text-black transition duration-200 ease-in rounded-lg {{ lower .Section }}">
@@ -33,6 +34,7 @@
           </p>
         </div>
       </a>
+      {{ end }}
       {{ end }}
       {{ end }}
     </div>


### PR DESCRIPTION
Just a day after this plugin was updated to 0.6, the following commit in the client: https://github.com/darkforest-eth/client/commit/f13ca37a82be9f886cf49dd5980c85f3cf1c1a10 broke this plugin as the corresponding utils to get/setDetailLevel is no longer exposed.
Given the recent optimizations in the client which essentially hides smaller planets automatically, this plugin is no longer needed.
I would propose deprecating this plugin (currently have marked the version as [DEPRECATED]). This can then be deleted in the future.