### PR TITLE
chore: Deprecate "Find Legendary" plugin

### DIFF
--- a/content/artifacts/find-legendary/index.md
+++ b/content/artifacts/find-legendary/index.md
@@ -3,4 +3,5 @@ title: Find Legendary
 date: 2021-01-25T00:34:46-07:00
 subtitle:
 version: 0.5.0
+deprecated: true
 ---


### PR DESCRIPTION
This plugin was just a proof-of-concept for an exploit in v0.5, so it should be deprecated and hidden now.