### PR TITLE
Update to use df.move instead of move

### DIFF
--- a/content/productivity/distribute-silver/plugin.js
+++ b/content/productivity/distribute-silver/plugin.js
@@ -1,7 +1,3 @@
-import {
-  move
-} from 'https://plugins.zkga.me/utils/queued-move.js';
-
 const MAX_LEVEL_PLANET = 9;
 
 class Plugin {

--- a/content/productivity/distribute-silver/plugin.js
+++ b/content/productivity/distribute-silver/plugin.js
@@ -251,7 +251,7 @@ function distributeSilver(fromId, maxDistributeEnergyPercent, minPLevel, toSpace
       continue;
     }
 
-    move(fromId, candidate.locationId, energyNeeded, silverNeeded);
+    df.move(fromId, candidate.locationId, energyNeeded, silverNeeded);
     energySpent += energyNeeded;
     silverSpent += silverNeeded;
     moves += 1;


### PR DESCRIPTION
Using df.move allows this plugin to match the user's gas price settings for each transaction, instead of defaulting to 1 gwei.

This does not create any changes in the UI.