### PR TITLE
fix plugin bug

### DIFF
--- a/content/productivity/centralize-ressources/plugin.js
+++ b/content/productivity/centralize-ressources/plugin.js
@@ -154,7 +154,8 @@ function receiveRessources(fromId, maxDistributeEnergyPercent, minPLevel, maxPle
     
             const energyBudget = Math.floor((maxDistributeEnergyPercent / 100) * candidate.energy);
            
-            const maxReceivedEnergyForMove = Math.ceil(df.getEnergyArrivingForMove(candidate.locationId, fromId, energyBudget));
+            const dist = df.getDist(from.locationId, candidate.locationId);
+            const maxReceivedEnergyForMove = Math.ceil(df.getEnergyArrivingForMove(candidate.locationId, fromId, dist, energyBudget));
             // only send enough energy to cap planet
             const receivedEnergyForMove = Math.ceil(maxEnergy - energyReceived - maxReceivedEnergyForMove >= 0? maxReceivedEnergyForMove: maxEnergy - energyReceived);
             // only send enough silver to cap planet


### PR DESCRIPTION
the `dist` param is missing when calling `getEnergyArrivingForMove`, add it back