### PR TITLE
chore: keep filename specific to each contract

### DIFF
--- a/content/utilities/map-export/plugin.js
+++ b/content/utilities/map-export/plugin.js
@@ -147,7 +147,7 @@ class Plugin {
       let map = JSON.stringify(mapRaw);
       var blob = new Blob([map], { type: 'application/json' }),
           anchor = document.createElement('a');
-      anchor.download = 'map.json';
+      anchor.download = df.getContractAddress().substring(0,6) + '_map.json';
       anchor.href = (window.webkitURL || window.URL).createObjectURL(blob);
       anchor.dataset.downloadurl = ['application/json', anchor.download, anchor.href].join(':');
       anchor.click();


### PR DESCRIPTION
 to prevent import the incorrect map across rounds