### PR TITLE
Limit the number of planets to send energy from

### DIFF
--- a/content/productivity/crawl-planets/index.md
+++ b/content/productivity/crawl-planets/index.md
@@ -2,5 +2,5 @@
 title: Crawl Planets
 date: 2021-07-29T14:00:00+02:00
 subtitle: Capture unowned planets around you!
-version: 0.6.1
+version: 0.6.0
 ---

--- a/content/productivity/crawl-planets/index.md
+++ b/content/productivity/crawl-planets/index.md
@@ -2,5 +2,5 @@
 title: Crawl Planets
 date: 2021-07-29T14:00:00+02:00
 subtitle: Capture unowned planets around you!
-version: 0.6.0
+version: 0.6.1
 ---

--- a/content/productivity/crawl-planets/plugin.js
+++ b/content/productivity/crawl-planets/plugin.js
@@ -261,7 +261,7 @@ class Plugin {
         let globalButton = document.createElement('button');
         globalButton.style.width = '100%';
         globalButton.style.marginBottom = '10px';
-        globalButton.innerHTML = 'Crawl everything!'
+        globalButton.innerHTML = 'Crawl everything near selected!'
         globalButton.onclick = () => {
             message.innerText = "Please wait...";
             let selectedPlanet = ui.getSelectedPlanet();


### PR DESCRIPTION
At the moment, if you have a large number of planets (say over 500) then the Crawl Planets plugin issues an unusably high number of moves.

This feature to improve Crawl Planets contains:
- A slider to set the max number of planets to move energy from:
  - between 1 and 1024
  - in powers of 2 (log slider more usable than linear slider)
- a filter on the planets selected to move energy
  - firstly, sort planets by how close they are to the selected planet (selection is now mandatory)
  - then filter to just the first 2^N planets in that list

Before, the Crawl Planets plugin could potentially issue a session-breaking 1000 moves, all over the game map

Now, maximum moves is limited to around 3 or 4 times the Max Planets value, centred on the selected planet so in a specific area of the game map.

Hope you find this a useful feature on the Crawl Planets plugin?

David