### PR TITLE
feat(remote-explorer): show tile size and pattern field name

### DIFF
--- a/content/productivity/remote-explore/plugin.js
+++ b/content/productivity/remote-explore/plugin.js
@@ -298,14 +298,18 @@ function App({
           placeholder="URL for explore server"
         />
         <select style=${select} value=${chunkSize} onChange=${changeChunkSize}>
-          ${CHUNK_SIZES.map((size) => html`
-            <option value="${size}">${size}</option>
-          `)}
+          <optgroup label="Tile size">
+            ${CHUNK_SIZES.map((size) => html`
+              <option value="${size}">${size}</option>
+            `)}
+          </optgroup>
         </select>
         <select style=${select} value=${patternType} onChange=${changePattern}>
-          <option value="spiral">Spiral</option>
-          <option value="swiss">Swiss</option>
-          <option value="towardsCenter">TowardsCenter</option>
+          <optgroup label="Pattern">
+            <option value="spiral">Spiral</option>
+            <option value="swiss">Swiss</option>
+            <option value="towardsCenter">TowardsCenter</option>
+          </optgroup>
         </select>
         <button style=${button} onClick=${add}>Explore!</button>
       </div>


### PR DESCRIPTION
I added an `optgroup` to the select options to provide some context to users. In #141 we mentioned a tooltip but I think this way looks cleaner.

![2021-08-18-162709_644x472_scrot](https://user-images.githubusercontent.com/282580/129926412-c2ec06a1-2759-4869-99e2-9249ee6869f5.png)
