### PR TITLE
Tiny Leaderboard - improvements

### DIFF
--- a/content/utilities/tiny-leaderboard/index.md
+++ b/content/utilities/tiny-leaderboard/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tiny Leaderboard
-date: 2021-08-13T12:00:00
+date: 2021-08-19T12:00:00
 subtitle: Shows a tiny leaderboard with timer
 version: 0.6.0
 ---

--- a/content/utilities/tiny-leaderboard/plugin.js
+++ b/content/utilities/tiny-leaderboard/plugin.js
@@ -141,7 +141,8 @@ function Plugin() {
 		let i = centerRank - leaderboardRange;
 		if (i < 0) i = 0;
 		let max = centerRank + leaderboardRange;
-		if (max-i < 10) max += 10 - (max-i); // show at least 11 players
+		let lr = leaderboardRange*2;
+		if (max-i < lr) max += lr - (max-i); // show at least leaderboardRange*2 + 1 players
 		for ( ; i < o.leaderboard.length && i <= max; ++i) {
 			o.addPlayerToBoard(table, o.leaderboard[i], i+1);
 		}

--- a/content/utilities/tiny-leaderboard/plugin.js
+++ b/content/utilities/tiny-leaderboard/plugin.js
@@ -2,18 +2,18 @@
 //
 // Shows a tiny leaderboard with a timer (until the round ends)
 // Shows the 5 people above and below you on the board
+// Hover over the countdown to see the exact date/time in your timezone
+// Click a planet from a different player to show them on the leaderboard
 // Updates every 60 seconds
 
 const updateTimeInSeconds = 60;
 const leaderboardRange = 5; // 5 people above and below you
 
+const emptyAddress = "0x0000000000000000000000000000000000000000";
+
 // ---------------------------------------------------------------
 
-// https://github.com/darkforest-eth/client/blob/master/src/Frontend/Views/Leaderboard.tsx#L118
-const roundEndTimestamp = '2021-08-22T16:00:00.000Z';
-const roundEndTime = new Date(roundEndTimestamp).getTime();
-// df.endTimeSeconds does not return the round end time - maybe this is a bug or something else can be used
-// const roundEndTime = df.endTimeSeconds*1000;
+let roundEndTime = new Date().getTime(); // for init set it to current time
 
 function formatDuration(durationMs) {
 	if (durationMs < 0) return '';
@@ -27,6 +27,11 @@ function formatDuration(durationMs) {
 
 function timestampSection(value) {
 	return value.toString().padStart(2, '0');
+}
+
+async function downloadRoundEndTime() {
+    let roundEnd = await df.contractsAPI.scoreContract.roundEnd();
+    roundEndTime = new Date(parseInt(roundEnd._hex, 16)*1000).getTime();
 }
 
 function getStrTimeUntilRoundEnds() {
@@ -65,15 +70,20 @@ function Plugin() {
 	o.updateLeaderboardInterv = null;
 	o.firstRender = true;
 	o.leaderboard = [];
+	o.centerPlayer = df.account;
 
-	o.init = function () {
+	o.init = function() {
+		downloadRoundEndTime().then(()=> {
+			o.div_timer.title = new Date(roundEndTime).toString();
+		});
 		o.updateTimerInterv = setInterval(o.updateTimer, 1000);
 		o.updateInterv = setInterval(o.updateLeaderboard, 1000 * updateTimeInSeconds);
 		o.updateTimer();
 		o.updateLeaderboard();
+		window.addEventListener("click", o.onMouseClick);
 	}
 
-	o.render = function (container) {
+	o.render = function(container) {
 		o.container = container;
 		o.container.style.width = '250px';
 
@@ -95,18 +105,27 @@ function Plugin() {
 		}
 	}
 
-	o.destroy = function () {
+	o.destroy = function() {
 		if (o.updateInterv !== null)
 			clearInterval(o.updateInterv);
 		if (o.updateTimerInterv !== null)
 			clearInterval(o.updateTimerInterv);
+		window.removeEventListener("click", o.onMouseClick);
+	}
+	
+	o.onMouseClick = function() {
+		let newPlayer = ui.selectedPlanet ? ui.selectedPlanet.owner : df.account;
+		if (newPlayer === o.centerPlayer) return;
+		if (newPlayer === emptyAddress) return;
+		o.centerPlayer = newPlayer;
+		o.updateLeaderboard();
 	}
 
 	o.updateTimer = function() {
 		o.div_timer.innerText = getStrTimeUntilRoundEnds();
 	}
 
-	o.updateLeaderboard = async function () {
+	o.updateLeaderboard = async function() {
 		o.leaderboard = await downloadLeaderboard();
 		o.leaderboard = o.leaderboard.entries;
 		o.leaderboard.sort((p1, p2) => {
@@ -118,17 +137,18 @@ function Plugin() {
 		o.div_playerList.innerText = "";
 		let table = document.createElement("table");
 		table.style.width = o.container.offsetWidth+"px";
-		let personalRank = o.getLeaderboardRank(df.account);
-		let i = personalRank - leaderboardRange;
+		let centerRank = o.getLeaderboardRank(o.centerPlayer);
+		let i = centerRank - leaderboardRange;
 		if (i < 0) i = 0;
-		let max = personalRank + leaderboardRange;
+		let max = centerRank + leaderboardRange;
+		if (max-i < 10) max += 10 - (max-i); // show at least 11 players
 		for ( ; i < o.leaderboard.length && i <= max; ++i) {
-			o.addPlayerToBoard(table, o.leaderboard[i], i);
+			o.addPlayerToBoard(table, o.leaderboard[i], i+1);
 		}
 		o.div_playerList.appendChild(table);
 	}
 
-	o.getLeaderboardRank = function (ethAddress) {
+	o.getLeaderboardRank = function(ethAddress) {
 		for (var i = 0; i < o.leaderboard.length; ++i) {
 			if (ethAddress === o.leaderboard[i].ethAddress)
 				return i;


### PR DESCRIPTION
- download round end time from contract (so it doesn't need to be changed every round, thanks to jacob rosenthal for link)
- show exact time str in your time zone when hovering over countdown
- fix rank number (add 1)  previously all ranks were off by one, rank 1 was 0
- show leaderboard depending on owner of selected planet - you can click on planets to see the leaderboard from a different perspective