### PR TITLE
2 plugin cleanups

### DIFF
--- a/content/productivity/range-attack/index.md
+++ b/content/productivity/range-attack/index.md
@@ -1,6 +1,6 @@
 ---
 title: Range Attack
-date: 2021-08-20-06T20:54:00-07:00
+date: 2021-08-20T20:54:00-07:00
 subtitle: Attack planets based on your selection with filters
 version: 0.6.4
 ---

--- a/content/utilities/scoring-planets/index.md
+++ b/content/utilities/scoring-planets/index.md
@@ -2,5 +2,5 @@
 title: Scoring Planets
 date: 2021-08-19T16:00:00-07:00
 subtitle: See the top scoring planets within your vision
-version: 0.6.4
+version: 0.6.3
 ---


### PR DESCRIPTION
Scoring plantets technically works fine, but its only useful for that 6.3 round where score was distance to center.
Range attack has a malformed date that cheekily always has it as the first plugin on the page