### PR TITLE
[remote-explore] fire event when chunks are mined 

### DIFF
--- a/content/productivity/remote-explore/plugin.js
+++ b/content/productivity/remote-explore/plugin.js
@@ -167,6 +167,7 @@ function MinerUI({
       } else {
         ui?.removeExtraMinerLocation?.(miner.id);
       }
+      df.minerManager.emit(NEW_CHUNK, chunk, miningTimeMillis);
     };
     miner.on(NEW_CHUNK, calcHash);
 


### PR DESCRIPTION
Makes the remote explorer fire events as soon as a chunk is mined.
This works the same way as the default web miner.
If you listen to the event it will be fired when either of them mines a chunk.

If you want to this this, run the miner and enter this into the console:
```js
function testMine(chunk, time) {
    console.log(time+" chunk", chunk);
}
df.minerManager.on("DiscoveredNewChunk", testMine);
```