### PR TITLE
fix-simultaneous-attack

### DIFF
--- a/content/productivity/simultaneous-attack/index.md
+++ b/content/productivity/simultaneous-attack/index.md
@@ -1,6 +1,6 @@
 ---
 title: Simultaneous attack
 date: 2021-07-16
-subtitle: Attack or reinforce a planet by automatically scheduling moves arrive at the same time
+subtitle: Attack or reinforce a planet by automatically scheduling up to 6 moves to arrive at the same time
 version: 0.6.4
 ---


### PR DESCRIPTION
I have:
- Fixed plugin so the slider value is actually feeding into the df.move (previously the slider displayed correctly, but the move was always 50% of energy)
- Provided 2 user parameters at top of file for easy customisation of defaults
- Slider value initialised correctly
- Slider label refactored
- Made plugin description slightly more specific