### PR TITLE
[remote-explore] fire event when chunks are mined

### DIFF
--- a/content/productivity/remote-explore/plugin.js
+++ b/content/productivity/remote-explore/plugin.js
@@ -167,6 +167,7 @@ function MinerUI({
       } else {
         ui?.removeExtraMinerLocation?.(miner.id);
       }
+      df.minerManager.emit(NEW_CHUNK, chunk, miningTimeMillis);
     };
     miner.on(NEW_CHUNK, calcHash);
 


### PR DESCRIPTION
Makes the remote explorer fire events as soon as a chunk is mined.
This works the same way as the default web miner.
If you listen to the event it will be fired when either of them mines a chunk.

If you want to test this, run the miner and enter this into the console:

```
function testMine(chunk, time) {
    console.log(time+" chunk", chunk);
}
df.minerManager.on("DiscoveredNewChunk", testMine);
```
Here is the code that fires the event in the default client:
https://github.com/darkforest-eth/client/blob/93e24f18d64ae506687e4e3a6e798ee46e84b286/src/Backend/Miner/MinerManager.ts#L156

I don't know much about how events work, if I did something wrong pls correct me.

EDIT: i accidentally closed this pr and had to make a new one, sorry