### PR TITLE
Fix versioning in template for 0.6.5

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
         href="https://github.com/{{ .Site.Params.Repo }}/blob/{{ .Site.Params.Branch }}/content/{{ .File.Dir }}plugin.js"
         class="card border-2 border-green-400 sm:mb-4 mb-6 hover:shadow-xl hover:bg-green-400 text-gray-400 hover:text-black transition duration-200 ease-in rounded-lg {{ lower .Section }}">
         <div class="flex flex-col justify-between h-full relative">
-          {{ if eq .Params.version "0.6.4" }}
+          {{ if eq .Params.version "0.6.5" }}
             <span
               class="bg-green-400 text-black px-3 py-1 tracking-widest text-xs absolute left-0 top-0 rounded-br rounded-tl">v{{ .Params.Version }}</span>
           {{ else }}


### PR DESCRIPTION
Currently plugins marked with the version 0.6.5 are shown as outdated:
<img width="360" alt="Plugin with version number on red background" src="https://user-images.githubusercontent.com/63682890/162108065-a9214af2-1a79-42a6-ba8c-d2d1615003bc.png">
While plugins in 0.6.4 are marked as up to date. 
